### PR TITLE
Fix Kotlin 2.0 Compose CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,27 @@
+name: Android CI
+on:
+  push: { branches: [ main ] }
+  pull_request: { branches: [ main ] }
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: android-actions/setup-android@v3
+        with:
+          api-level: 34
+          build-tools: 34.0.0
+      - uses: gradle/gradle-build-action@v3
+        with:
+          gradle-version: 8.7
+          arguments: assembleDebug
+      - uses: actions/upload-artifact@v4
+        with:
+          name: app-debug
+          path: '**/build/outputs/apk/debug/*.apk'

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,47 @@
+plugins {
+  id("com.android.application")
+  id("org.jetbrains.kotlin.android")
+  id("org.jetbrains.kotlin.plugin.compose")   // Kotlin 2.0 必需
+}
+
+android {
+  namespace = "com.soullinker.tftagent"
+  compileSdk = 34
+
+  defaultConfig {
+    applicationId = "com.soullinker.tftagent"
+    minSdk = 24
+    targetSdk = 34
+    versionCode = 1
+    versionName = "0.1.0"
+  }
+
+  buildTypes {
+    release {
+      isMinifyEnabled = false
+      proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+    }
+    debug { isDebuggable = true }
+  }
+
+  buildFeatures { compose = true }
+
+  // Kotlin 2.0 起不再使用 composeOptions 的 kotlinCompilerExtensionVersion，故不写
+  packaging { resources { excludes += "/META-INF/{AL2.0,LGPL2.1}" } }
+}
+
+dependencies {
+  val bom = platform("androidx.compose:compose-bom:2024.09.01")
+  implementation(bom); androidTestImplementation(bom)
+  implementation("androidx.core:core-ktx:1.13.1")
+  implementation("androidx.activity:activity-compose:1.9.2")
+  implementation("androidx.compose.ui:ui")
+  implementation("androidx.compose.ui:ui-tooling-preview")
+  implementation("androidx.compose.material3:material3:1.3.0")
+  debugImplementation("androidx.compose.ui:ui-tooling")
+  debugImplementation("androidx.compose.ui:ui-test-manifest")
+  testImplementation("junit:junit:4.13.2")
+  androidTestImplementation("androidx.test.ext:junit:1.2.1")
+  androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+  androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <application>
+    <activity android:name=".MainActivity" android:exported="true">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+  </application>
+</manifest>

--- a/app/src/main/java/com/soullinker/tftagent/MainActivity.kt
+++ b/app/src/main/java/com/soullinker/tftagent/MainActivity.kt
@@ -1,0 +1,35 @@
+package com.soullinker.tftagent
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+class MainActivity : ComponentActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContent {
+      Scaffold { padding ->
+        Box(Modifier.fillMaxSize().padding(padding)) { Greeting("TFT Agent") }
+      }
+    }
+  }
+}
+
+@Composable
+fun Greeting(text: String) {
+  Text("Hello $text")
+}
+
+@Preview
+@Composable
+fun PreviewGreeting() {
+  Greeting("Preview")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,6 @@
+// Kotlin 2.0 requires the Compose compiler Gradle plugin to be declared at the root.
+plugins {
+  id("com.android.application") version "8.6.0" apply false
+  id("org.jetbrains.kotlin.android") version "2.0.0" apply false
+  id("org.jetbrains.kotlin.plugin.compose") version "2.0.0" apply false
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.nonTransitiveRClass=true
+kotlin.code.style=official

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,20 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
+pluginManagement {
+  repositories {
+    gradlePluginPortal()
+    google()
+    mavenCentral()
+  }
+}
+
+dependencyResolutionManagement {
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    google()
+    mavenCentral()
+  }
+}
+
+rootProject.name = "tft-agent-android"
+include(":app")


### PR DESCRIPTION
## Summary
- enable the Kotlin Compose Gradle plugin at the root to align with Kotlin 2.0 requirements
- activate the Compose plugin in the app module while relying on the plugin-managed compiler configuration and keeping the minimal dependencies
- ensure the Android CI workflow builds the debug APK with fixed toolchain versions and uploads it as an artifact

## Testing
- not run (CI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68da77b4dcc08331bb01ea3e2435a21a