### PR TITLE
Add ExocadDailyExporter WinForms tray tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore ExocadDailyExporter.sln
+
+      - name: Publish
+        shell: pwsh
+        run: |
+          $publishDir = "dist/win-x64"
+          if (Test-Path 'dist') { Remove-Item 'dist' -Recurse -Force }
+          dotnet publish ExocadDailyExporter.sln -c Release -r win-x64 -p:PublishSingleFile=true -p:SelfContained=true -p:IncludeNativeLibrariesForSelfExtract=true -p:EnableCompressionInSingleFile=true -o $publishDir
+          Copy-Item ExocadDailyExporter/appsettings.json $publishDir -Force
+          Copy-Item ExocadDailyExporter/README.md $publishDir -Force
+          Compress-Archive -Path "$publishDir/*" -DestinationPath "dist/ExocadDailyExporter-win-x64.zip"
+
+      - name: Create Release
+        id: release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/ExocadDailyExporter-win-x64.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish summary
+        if: always()
+        shell: pwsh
+        run: |
+          $releaseUrl = "https://github.com/${{ github.repository }}/releases/tag/${{ github.ref_name }}"
+          $downloadUrl = '${{ steps.release.outputs.browser_download_url }}'
+          if (-not $downloadUrl) {
+            $downloadUrl = '浏览 Release 页面下载'
+          }
+          "Release 页面：$releaseUrl" | Set-Content -Path summary.txt
+          "直接下载：$downloadUrl" | Add-Content -Path summary.txt
+          Get-Content summary.txt
+          Get-Content summary.txt | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append

--- a/ExocadDailyExporter.Tests/ExocadDailyExporter.Tests.csproj
+++ b/ExocadDailyExporter.Tests/ExocadDailyExporter.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ExocadDailyExporter\ExocadDailyExporter.csproj" />
+  </ItemGroup>
+</Project>

--- a/ExocadDailyExporter.Tests/ImportServiceTests.cs
+++ b/ExocadDailyExporter.Tests/ImportServiceTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using ExocadDailyExporter.Models;
+using ExocadDailyExporter.Services;
+using Xunit;
+
+namespace ExocadDailyExporter.Tests;
+
+public class ImportServiceTests
+{
+    private static Config CreateConfig(string sourceRoot, string archiveRoot, int stabilizeSeconds = 1)
+    {
+        return new Config
+        {
+            SourceRoot = sourceRoot,
+            ArchiveRoot = archiveRoot,
+            StabilizeSeconds = stabilizeSeconds,
+            DailyTime = "19:00",
+            RunAtStartup = false,
+            KeepLogDays = 7,
+            ExcludePatterns = new List<string> { "crashreport*", "*preview*.stl", "*screenshot*.png" }
+        };
+    }
+
+    [Fact]
+    public void AllowedPatternsMatch()
+    {
+        var config = CreateConfig("C:/temp", "C:/out");
+        var logger = new Logger(7);
+        using var service = new ImportService(config, logger);
+
+        Assert.True(service.IsAllowedFile(Path.Combine(config.SourceRoot, "case", "tooth_crown_cad.stl")));
+        Assert.True(service.IsAllowedFile(Path.Combine(config.SourceRoot, "case", "test.constructionInfo")));
+        Assert.False(service.IsAllowedFile(Path.Combine(config.SourceRoot, "case", "model.dentalProject")));
+        Assert.False(service.IsAllowedFile(Path.Combine(config.SourceRoot, "case", "mesh_preview_cad.stl")));
+    }
+
+    [Fact]
+    public void ExcludePatternsWin()
+    {
+        var config = CreateConfig("C:/temp", "C:/out");
+        config.ExcludePatterns.Add("*_tmp.stl");
+        var logger = new Logger(7);
+        using var service = new ImportService(config, logger);
+
+        Assert.False(service.IsAllowedFile(Path.Combine(config.SourceRoot, "case", "demo_tmp.stl")));
+    }
+
+    [Fact]
+    public async Task ImportTodayCopiesFiles()
+    {
+        var source = CreateTempDirectory();
+        var archive = CreateTempDirectory();
+        try
+        {
+            var caseDir = Path.Combine(source, "Case001");
+            Directory.CreateDirectory(caseDir);
+            var file = Path.Combine(caseDir, "sample_crown_cad.stl");
+            await File.WriteAllTextAsync(file, "hello");
+            File.SetLastWriteTime(file, DateTime.Now.AddMinutes(-5));
+
+            var config = CreateConfig(source, archive);
+            var logger = new Logger(7);
+            using var service = new ImportService(config, logger);
+
+            var count = await service.ImportTodayAsync(CancellationToken.None);
+            Assert.Equal(1, count);
+
+            var today = DateTime.Today;
+            var target = Path.Combine(archive, today.ToString("yyyy"), today.ToString("yyyy-MM-dd"), "Case001", "sample_crown_cad.stl");
+            Assert.True(File.Exists(target));
+        }
+        finally
+        {
+            TryDelete(source);
+            TryDelete(archive);
+        }
+    }
+
+    [Fact]
+    public async Task NewerTargetIsNotOverwritten()
+    {
+        var source = CreateTempDirectory();
+        var archive = CreateTempDirectory();
+        try
+        {
+            var caseDir = Path.Combine(source, "Case002");
+            Directory.CreateDirectory(caseDir);
+            var file = Path.Combine(caseDir, "bridge_cad.stl");
+            await File.WriteAllTextAsync(file, "source v1");
+            File.SetLastWriteTime(file, DateTime.Now.AddMinutes(-10));
+
+            var config = CreateConfig(source, archive);
+            var logger = new Logger(7);
+            using var service = new ImportService(config, logger);
+
+            await service.ImportCaseDirectoryAsync(caseDir, CancellationToken.None);
+
+            var today = DateTime.Today;
+            var target = Path.Combine(archive, today.ToString("yyyy"), today.ToString("yyyy-MM-dd"), "Case002", "bridge_cad.stl");
+            Assert.True(File.Exists(target));
+
+            await File.WriteAllTextAsync(target, "target v2");
+            File.SetLastWriteTime(target, DateTime.Now);
+
+            await service.ImportCaseDirectoryAsync(caseDir, CancellationToken.None);
+            var content = await File.ReadAllTextAsync(target);
+            Assert.Equal("target v2", content);
+        }
+        finally
+        {
+            TryDelete(source);
+            TryDelete(archive);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "ExocadDailyExporterTests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (!string.IsNullOrEmpty(path) && Directory.Exists(path))
+            {
+                Directory.Delete(path, true);
+            }
+        }
+        catch
+        {
+            // ignore cleanup errors
+        }
+    }
+}

--- a/ExocadDailyExporter.sln
+++ b/ExocadDailyExporter.sln
@@ -1,0 +1,27 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34031.279
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExocadDailyExporter", "ExocadDailyExporter\\ExocadDailyExporter.csproj", "{170BC2A1-564A-4F56-A394-2EE45D5EAEE0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExocadDailyExporter.Tests", "ExocadDailyExporter.Tests\\ExocadDailyExporter.Tests.csproj", "{89676128-08CA-4102-9C14-50FC500FE192}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {170BC2A1-564A-4F56-A394-2EE45D5EAEE0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {170BC2A1-564A-4F56-A394-2EE45D5EAEE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {170BC2A1-564A-4F56-A394-2EE45D5EAEE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {170BC2A1-564A-4F56-A394-2EE45D5EAEE0}.Release|Any CPU.Build.0 = Release|Any CPU
+        {89676128-08CA-4102-9C14-50FC500FE192}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {89676128-08CA-4102-9C14-50FC500FE192}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {89676128-08CA-4102-9C14-50FC500FE192}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {89676128-08CA-4102-9C14-50FC500FE192}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(SolutionProperties) = preSolution
+        HideSolutionNode = FALSE
+    EndGlobalSection
+EndGlobal

--- a/ExocadDailyExporter/ExocadDailyExporter.csproj
+++ b/ExocadDailyExporter/ExocadDailyExporter.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/ExocadDailyExporter/FirstRunForm.cs
+++ b/ExocadDailyExporter/FirstRunForm.cs
@@ -1,0 +1,132 @@
+using System;
+using System.IO;
+using System.Windows.Forms;
+
+namespace ExocadDailyExporter;
+
+public enum FirstRunResult
+{
+    Cancel,
+    SaveOnly,
+    StartNow
+}
+
+public class FirstRunForm : Form
+{
+    private readonly TextBox _txtArchiveRoot = new();
+    private readonly Button _btnBrowse = new();
+    private readonly Button _btnStart = new();
+    private readonly Button _btnSave = new();
+
+    public FirstRunForm(string? archiveRoot)
+    {
+        Text = "设置归档路径";
+        Width = 520;
+        Height = 180;
+        StartPosition = FormStartPosition.CenterScreen;
+        FormBorderStyle = FormBorderStyle.FixedDialog;
+        MaximizeBox = false;
+        MinimizeBox = false;
+
+        var label = new Label
+        {
+            Text = "请选择用于存放归档文件的目标文件夹：",
+            Dock = DockStyle.Top,
+            Height = 30
+        };
+
+        _txtArchiveRoot.Text = archiveRoot ?? string.Empty;
+        _txtArchiveRoot.Dock = DockStyle.Fill;
+
+        _btnBrowse.Text = "浏览...";
+        _btnBrowse.Width = 80;
+        _btnBrowse.Click += (_, _) => BrowseArchive();
+
+        _btnStart.Text = "开始运行";
+        _btnStart.Dock = DockStyle.Fill;
+        _btnStart.Height = 40;
+        _btnStart.Click += (_, _) => OnStartClicked();
+
+        _btnSave.Text = "仅保存";
+        _btnSave.Dock = DockStyle.Fill;
+        _btnSave.Height = 40;
+        _btnSave.Click += (_, _) => OnSaveClicked();
+
+        var pathPanel = new TableLayoutPanel
+        {
+            Dock = DockStyle.Top,
+            ColumnCount = 2,
+            Height = 35
+        };
+        pathPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
+        pathPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 90));
+        pathPanel.Controls.Add(_txtArchiveRoot, 0, 0);
+        pathPanel.Controls.Add(_btnBrowse, 1, 0);
+
+        var buttonPanel = new TableLayoutPanel
+        {
+            Dock = DockStyle.Top,
+            ColumnCount = 2,
+            Height = 50,
+            Padding = new Padding(0, 10, 0, 0)
+        };
+        buttonPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50));
+        buttonPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50));
+        buttonPanel.Controls.Add(_btnStart, 0, 0);
+        buttonPanel.Controls.Add(_btnSave, 1, 0);
+
+        Controls.Add(buttonPanel);
+        Controls.Add(pathPanel);
+        Controls.Add(label);
+
+        AcceptButton = _btnStart;
+    }
+
+    public string ArchiveRoot => _txtArchiveRoot.Text.Trim();
+
+    public FirstRunResult Result { get; private set; } = FirstRunResult.Cancel;
+
+    private void BrowseArchive()
+    {
+        using var dialog = new FolderBrowserDialog
+        {
+            Description = "选择归档文件夹"
+        };
+
+        if (Directory.Exists(ArchiveRoot))
+        {
+            dialog.SelectedPath = ArchiveRoot;
+        }
+
+        if (dialog.ShowDialog(this) == DialogResult.OK)
+        {
+            _txtArchiveRoot.Text = dialog.SelectedPath;
+        }
+    }
+
+    private void OnStartClicked()
+    {
+        if (string.IsNullOrWhiteSpace(ArchiveRoot))
+        {
+            MessageBox.Show(this, "请先选择归档路径。", Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            return;
+        }
+
+        Result = FirstRunResult.StartNow;
+        DialogResult = DialogResult.OK;
+        Close();
+    }
+
+    private void OnSaveClicked()
+    {
+        if (string.IsNullOrWhiteSpace(ArchiveRoot))
+        {
+            MessageBox.Show(this, "请先选择归档路径。", Text, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            return;
+        }
+
+        Result = FirstRunResult.SaveOnly;
+        DialogResult = DialogResult.OK;
+        Close();
+    }
+}

--- a/ExocadDailyExporter/MainForm.cs
+++ b/ExocadDailyExporter/MainForm.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+using ExocadDailyExporter.Models;
+
+namespace ExocadDailyExporter;
+
+public class MainForm : Form
+{
+    private readonly TextBox _txtSourceRoot = new();
+    private readonly TextBox _txtArchiveRoot = new();
+    private readonly TextBox _txtDailyTime = new();
+    private readonly NumericUpDown _numStabilize = new();
+    private readonly NumericUpDown _numKeepLogs = new();
+    private readonly CheckBox _chkRunAtStartup = new();
+    private readonly Button _btnBrowseSource = new();
+    private readonly Button _btnBrowseArchive = new();
+    private readonly Button _btnSaveRestart = new();
+    private readonly Button _btnImportToday = new();
+    private readonly Button _btnOpenArchive = new();
+    private readonly Button _btnOpenLogs = new();
+    private readonly TextBox _txtLogs = new();
+    private readonly Label _lblStatus = new();
+    private readonly System.Collections.Generic.List<string> _excludePatterns;
+
+    public event EventHandler<Config>? SaveRequested;
+    public event EventHandler? ImportTodayRequested;
+    public event EventHandler? OpenArchiveRequested;
+    public event EventHandler? OpenLogsRequested;
+
+    public MainForm(Config config)
+    {
+        _excludePatterns = config.ExcludePatterns.ToList();
+        Text = "Exocad 档案导出助手";
+        Width = 680;
+        Height = 520;
+        StartPosition = FormStartPosition.CenterScreen;
+
+        _txtSourceRoot.Width = 400;
+        _txtArchiveRoot.Width = 400;
+        _txtDailyTime.Width = 80;
+
+        _numStabilize.Minimum = 5;
+        _numStabilize.Maximum = 600;
+        _numStabilize.Value = config.StabilizeSeconds;
+
+        _numKeepLogs.Minimum = 1;
+        _numKeepLogs.Maximum = 365;
+        _numKeepLogs.Value = config.KeepLogDays;
+
+        _chkRunAtStartup.Text = "开机自启";
+        _chkRunAtStartup.Checked = config.RunAtStartup;
+
+        _btnBrowseSource.Text = "浏览...";
+        _btnBrowseSource.Click += (_, _) => BrowseFolder(_txtSourceRoot);
+
+        _btnBrowseArchive.Text = "浏览...";
+        _btnBrowseArchive.Click += (_, _) => BrowseFolder(_txtArchiveRoot);
+
+        _btnSaveRestart.Text = "保存并重启服务";
+        _btnSaveRestart.Width = 150;
+        _btnSaveRestart.Click += (_, _) => OnSaveClicked();
+
+        _btnImportToday.Text = "立刻导入今天";
+        _btnImportToday.Width = 150;
+        _btnImportToday.Click += (_, _) => ImportTodayRequested?.Invoke(this, EventArgs.Empty);
+
+        _btnOpenArchive.Text = "打开归档文件夹";
+        _btnOpenArchive.Width = 150;
+        _btnOpenArchive.Click += (_, _) => OpenArchiveRequested?.Invoke(this, EventArgs.Empty);
+
+        _btnOpenLogs.Text = "打开日志文件夹";
+        _btnOpenLogs.Width = 150;
+        _btnOpenLogs.Click += (_, _) => OpenLogsRequested?.Invoke(this, EventArgs.Empty);
+
+        _txtLogs.Multiline = true;
+        _txtLogs.ReadOnly = true;
+        _txtLogs.ScrollBars = ScrollBars.Vertical;
+        _txtLogs.Dock = DockStyle.Fill;
+
+        _lblStatus.ForeColor = Color.DarkOrange;
+        _lblStatus.Dock = DockStyle.Top;
+        _lblStatus.Height = 40;
+
+        var table = new TableLayoutPanel
+        {
+            Dock = DockStyle.Top,
+            ColumnCount = 3,
+            RowCount = 6,
+            AutoSize = true
+        };
+        table.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 120));
+        table.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100));
+        table.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 90));
+
+        AddRow(table, 0, "病例根目录", _txtSourceRoot, _btnBrowseSource);
+        AddRow(table, 1, "归档路径", _txtArchiveRoot, _btnBrowseArchive);
+        AddRow(table, 2, "稳定等待(秒)", _numStabilize, null);
+        AddRow(table, 3, "每日全量时间", _txtDailyTime, null);
+        AddRow(table, 4, "日志保留(天)", _numKeepLogs, null);
+        AddRow(table, 5, string.Empty, _chkRunAtStartup, null);
+
+        var buttonPanel = new FlowLayoutPanel
+        {
+            Dock = DockStyle.Top,
+            FlowDirection = FlowDirection.LeftToRight,
+            AutoSize = true,
+            Padding = new Padding(0, 10, 0, 10)
+        };
+        buttonPanel.Controls.AddRange(new Control[]
+        {
+            _btnSaveRestart,
+            _btnImportToday,
+            _btnOpenArchive,
+            _btnOpenLogs
+        });
+
+        var logPanel = new GroupBox
+        {
+            Text = "运行日志",
+            Dock = DockStyle.Fill
+        };
+        logPanel.Controls.Add(_txtLogs);
+
+        var container = new Panel { Dock = DockStyle.Fill };
+        container.Controls.Add(logPanel);
+        container.Controls.Add(buttonPanel);
+        container.Controls.Add(table);
+        container.Controls.Add(_lblStatus);
+
+        Controls.Add(container);
+
+        LoadConfig(config);
+    }
+
+    public void LoadConfig(Config config)
+    {
+        _txtSourceRoot.Text = config.SourceRoot;
+        _txtArchiveRoot.Text = config.ArchiveRoot;
+        _txtDailyTime.Text = config.DailyTime;
+        _numStabilize.Value = Math.Min(_numStabilize.Maximum, Math.Max(_numStabilize.Minimum, config.StabilizeSeconds));
+        _numKeepLogs.Value = Math.Min(_numKeepLogs.Maximum, Math.Max(_numKeepLogs.Minimum, config.KeepLogDays));
+        _chkRunAtStartup.Checked = config.RunAtStartup;
+        _excludePatterns.Clear();
+        _excludePatterns.AddRange(config.ExcludePatterns);
+    }
+
+    public void AppendLog(string message)
+    {
+        if (InvokeRequired)
+        {
+            BeginInvoke(new Action<string>(AppendLog), message);
+            return;
+        }
+
+        _txtLogs.AppendText(message + Environment.NewLine);
+        _txtLogs.SelectionStart = _txtLogs.TextLength;
+        _txtLogs.ScrollToCaret();
+    }
+
+    public void SetStatusMessage(string? message)
+    {
+        if (InvokeRequired)
+        {
+            BeginInvoke(new Action<string?>(SetStatusMessage), message);
+            return;
+        }
+
+        _lblStatus.Text = message ?? string.Empty;
+        _lblStatus.Visible = !string.IsNullOrEmpty(message);
+    }
+
+    private void OnSaveClicked()
+    {
+        var config = new Config
+        {
+            SourceRoot = _txtSourceRoot.Text.Trim(),
+            ArchiveRoot = _txtArchiveRoot.Text.Trim(),
+            StabilizeSeconds = (int)_numStabilize.Value,
+            DailyTime = _txtDailyTime.Text.Trim(),
+            RunAtStartup = _chkRunAtStartup.Checked,
+            KeepLogDays = (int)_numKeepLogs.Value,
+            ExcludePatterns = _excludePatterns.ToList()
+        };
+
+        SaveRequested?.Invoke(this, config);
+    }
+
+    private static void AddRow(TableLayoutPanel table, int row, string labelText, Control input, Control? button)
+    {
+        table.RowStyles.Add(new RowStyle(SizeType.Absolute, 30));
+        if (!string.IsNullOrEmpty(labelText))
+        {
+            var label = new Label
+            {
+                Text = labelText,
+                TextAlign = ContentAlignment.MiddleRight,
+                Dock = DockStyle.Fill
+            };
+            table.Controls.Add(label, 0, row);
+        }
+        else
+        {
+            table.Controls.Add(new Label { Text = string.Empty }, 0, row);
+        }
+
+        input.Dock = DockStyle.Fill;
+        table.Controls.Add(input, 1, row);
+
+        if (button != null)
+        {
+            table.Controls.Add(button, 2, row);
+        }
+        else
+        {
+            table.Controls.Add(new Label { Text = string.Empty }, 2, row);
+        }
+    }
+
+    private static void BrowseFolder(TextBox target)
+    {
+        using var dialog = new FolderBrowserDialog();
+        if (Directory.Exists(target.Text))
+        {
+            dialog.SelectedPath = target.Text;
+        }
+
+        if (dialog.ShowDialog() == DialogResult.OK)
+        {
+            target.Text = dialog.SelectedPath;
+        }
+    }
+}

--- a/ExocadDailyExporter/Models/Config.cs
+++ b/ExocadDailyExporter/Models/Config.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ExocadDailyExporter.Models;
+
+public class Config
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public string SourceRoot { get; set; } = "D:/Exocad-Allinone-3.0/CAD/exocad-DentalCAD3.0-2021-03-25/CAD-Data";
+
+    public string ArchiveRoot { get; set; } = string.Empty;
+
+    public int StabilizeSeconds { get; set; } = 30;
+
+    public string DailyTime { get; set; } = "19:00";
+
+    public bool RunAtStartup { get; set; } = true;
+
+    public int KeepLogDays { get; set; } = 30;
+
+    public List<string> ExcludePatterns { get; set; } = new()
+    {
+        "crashreport*",
+        "*preview*.stl",
+        "*screenshot*.png"
+    };
+
+    [JsonIgnore]
+    public static string ConfigFileName => "appsettings.json";
+
+    [JsonIgnore]
+    public static string AppDirectory => AppContext.BaseDirectory;
+
+    [JsonIgnore]
+    public static string ConfigPath => Path.Combine(AppDirectory, ConfigFileName);
+
+    public static Config Load()
+    {
+        var path = ConfigPath;
+        if (!File.Exists(path))
+        {
+            var config = new Config();
+            config.Save();
+            return config;
+        }
+
+        using var stream = File.OpenRead(path);
+        var configFromFile = JsonSerializer.Deserialize<Config>(stream, SerializerOptions) ?? new Config();
+        configFromFile.Normalize();
+        return configFromFile;
+    }
+
+    public void Save()
+    {
+        Normalize();
+        var path = ConfigPath;
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var json = JsonSerializer.Serialize(this, SerializerOptions);
+        File.WriteAllText(path, json);
+    }
+
+    public TimeSpan GetDailyTimeOfDay()
+    {
+        if (TimeSpan.TryParse(DailyTime, out var time))
+        {
+            return time;
+        }
+
+        return new TimeSpan(19, 0, 0);
+    }
+
+    private void Normalize()
+    {
+        SourceRoot = NormalizePath(SourceRoot);
+        ArchiveRoot = NormalizePath(ArchiveRoot);
+        if (StabilizeSeconds < 5)
+        {
+            StabilizeSeconds = 5;
+        }
+
+        if (KeepLogDays < 1)
+        {
+            KeepLogDays = 1;
+        }
+
+        DailyTime = GetDailyTimeOfDay().ToString("HH\:mm");
+        ExcludePatterns = ExcludePatterns?.Where(p => !string.IsNullOrWhiteSpace(p)).Select(p => p.Trim()).ToList() ?? new List<string>();
+    }
+
+    private static string NormalizePath(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        return value.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
+    }
+}

--- a/ExocadDailyExporter/Program.cs
+++ b/ExocadDailyExporter/Program.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Windows.Forms;
+using ExocadDailyExporter.Models;
+using ExocadDailyExporter.Services;
+
+namespace ExocadDailyExporter;
+
+internal static class Program
+{
+    private const string MutexName = "Global\\ExocadDailyExporter";
+
+    [STAThread]
+    private static void Main(string[] args)
+    {
+        using var mutex = new Mutex(true, MutexName, out var created);
+        if (!created)
+        {
+            MessageBox.Show("程序已在运行。", "ExocadDailyExporter", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        if (args.Any(a => string.Equals(a, "--daily-run", StringComparison.OrdinalIgnoreCase)))
+        {
+            RunDailyImport();
+            return;
+        }
+
+        ApplicationConfiguration.Initialize();
+        Application.Run(new TrayAppContext());
+    }
+
+    private static void RunDailyImport()
+    {
+        try
+        {
+            var config = Config.Load();
+            var logger = new Logger(config.KeepLogDays);
+            using var importService = new ImportService(config, logger);
+            logger.Info("计划任务触发的全量扫描开始...");
+            var count = importService.ImportTodayAsync(CancellationToken.None).GetAwaiter().GetResult();
+            logger.Info($"计划任务触发的全量扫描完成，共处理 {count} 个病例。");
+        }
+        catch (Exception ex)
+        {
+            MessageBox.Show($"计划任务执行失败：{ex.Message}", "ExocadDailyExporter", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+}
+
+internal static class ApplicationConfiguration
+{
+    public static void Initialize()
+    {
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+    }
+}

--- a/ExocadDailyExporter/README.md
+++ b/ExocadDailyExporter/README.md
@@ -1,0 +1,58 @@
+# ExocadDailyExporter
+
+ExocadDailyExporter 是一个基于 .NET 8 的 Windows 托盘常驻小程序，用于自动收集 exocad 病例目录中的制造用文件，并每天归档到指定目录，方便与加工端共享。
+
+## 核心能力
+
+- 首次启动引导设置归档目录，可立即执行“今天全量扫描归档”。
+- 双击即运行，无需安装，支持单实例常驻托盘。
+- 实时监听病例目录内的白名单文件更新，自动归档到 `归档根目录\年\日期\病例名` 结构。
+- 内置白名单严格匹配制造 STL 与处方 XML，显式排除预览图、截图、崩溃报告等文件。
+- 计划任务（`schtasks`）按每日固定时间触发全量扫描；若计划任务不可用，则自动退回“启动文件夹”自启并给出提示。
+- 开机自启开关、稳定等待秒数、日志保留天数、每日全量时间等都可在设置界面修改并立即生效。
+- 日志按天滚动保存于 `logs\archive-YYYYMMDD.log`。
+
+## 快速上手
+
+1. 下载发布包并解压，双击 `ExocadDailyExporter.exe`。
+2. 首次启动会弹出“设置归档路径”对话框，选择归档目录后点击“开始运行”即可完成初始化并执行一次全量归档。
+3. 程序将最小化到托盘，右键图标可打开“设置…”、“立刻导入今天”、“打开归档文件夹”、“打开日志文件夹”或退出程序。
+4. 在设置窗口内可调整源目录、归档目录、稳定等待秒数、每日全量时间、日志保留天数及开机自启，并查看实时日志。
+
+## 白名单规则
+
+仅复制以下文件（大小写不敏感）：
+
+- 制造 STL：`*_crown_cad.stl`、`*_fullcontour_cad.stl`、`*_reduced_cad.stl`、`*_coping_cad.stl`、`*_veneer_cad.stl`、`*_inlay_cad.stl`、`*_onlay_cad.stl`、`*_overlay_cad.stl`、`*bridge*_cad.stl`、`*_pontic_cad.stl`、`*_abutment_cad.stl`、`*_meso_cad.stl`、`*_crown_implant_cad.stl`、`*_sleeve_cad.stl`、`*_tibase_cad.stl`、`*_bar_cad.stl`、`*_provisional_cad.stl`、`*_temp_cad.stl`、`*_longterm_temp_cad.stl`、`*_splint_cad.stl`、`*_bite_splint_cad.stl`、`*_setup_cad.stl`、`*_tryin_cad.stl`、`*_base_cad.stl`、`*_denture_cad.stl`、`*_gingiva_cad.stl`、`*_primary_telescopic_cad.stl`、`*_secondary_telescopic_cad.stl`、`*_post_cad.stl`、`*_core_cad.stl`、`*_rpd_cad.stl`、`*_framework_cad.stl`、`*_ramp_cad.stl`。
+- 处方 XML：`*.constructionInfo`
+
+显式排除：`crashreport*`、`*preview*.stl`、`*screenshot*.png`。
+
+## 构建与发布
+
+### 本地发布
+
+执行项目根目录中的 `build.ps1`，脚本会完成以下工作：
+
+1. `dotnet restore`
+2. `dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true -p:SelfContained=true -p:IncludeNativeLibrariesForSelfExtract=true -p:EnableCompressionInSingleFile=true -o dist/win-x64`
+3. 打包 `dist/win-x64` 目录下的 `ExocadDailyExporter.exe`、`appsettings.json`、`README.md` 为 `dist/ExocadDailyExporter-win-x64.zip`
+4. 生成 `dist/download-link.txt`，包含本地压缩包的 `file://` 下载链接
+
+### GitHub Actions
+
+`.github/workflows/release.yml` 提供了手动/打标签触发的发布流程，会自动构建压缩包并上传到 Release，同步在 Job Summary 中输出 Release 页面与直链地址。
+
+## 单元测试
+
+项目使用 xUnit 覆盖白名单匹配、排除策略、覆盖策略以及当日变更判定逻辑：
+
+```bash
+ dotnet test
+```
+
+## 注意事项
+
+- 程序不需要管理员权限即可运行；如计划任务创建失败将自动回落到“启动文件夹”自启并在状态栏提示原因。
+- 请确保源目录和归档目录均位于本地磁盘或高速网络盘，避免频繁 IO 错误。
+- 稳定等待秒数用于避免复制未写完的文件，建议保持默认 30 秒，根据设备性能适度调整。

--- a/ExocadDailyExporter/Services/ImportService.cs
+++ b/ExocadDailyExporter/Services/ImportService.cs
@@ -1,0 +1,406 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ExocadDailyExporter.Models;
+
+namespace ExocadDailyExporter.Services;
+
+public class ImportService : IDisposable
+{
+    private static readonly string[] AllowedPatterns =
+    {
+        "*_crown_cad.stl",
+        "*_fullcontour_cad.stl",
+        "*_reduced_cad.stl",
+        "*_coping_cad.stl",
+        "*_veneer_cad.stl",
+        "*_inlay_cad.stl",
+        "*_onlay_cad.stl",
+        "*_overlay_cad.stl",
+        "*bridge*_cad.stl",
+        "*_pontic_cad.stl",
+        "*_abutment_cad.stl",
+        "*_meso_cad.stl",
+        "*_crown_implant_cad.stl",
+        "*_sleeve_cad.stl",
+        "*_tibase_cad.stl",
+        "*_bar_cad.stl",
+        "*_provisional_cad.stl",
+        "*_temp_cad.stl",
+        "*_longterm_temp_cad.stl",
+        "*_splint_cad.stl",
+        "*_bite_splint_cad.stl",
+        "*_setup_cad.stl",
+        "*_tryin_cad.stl",
+        "*_base_cad.stl",
+        "*_denture_cad.stl",
+        "*_gingiva_cad.stl",
+        "*_primary_telescopic_cad.stl",
+        "*_secondary_telescopic_cad.stl",
+        "*_post_cad.stl",
+        "*_core_cad.stl",
+        "*_rpd_cad.stl",
+        "*_framework_cad.stl",
+        "*_ramp_cad.stl",
+        "*.constructionInfo"
+    };
+
+    private readonly Config _config;
+    private readonly Logger _logger;
+    private readonly TimeSpan _stabilizeDuration;
+    private readonly HashSet<string> _activeCases = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _caseLock = new();
+    private readonly CancellationTokenSource _cts = new();
+
+    public ImportService(Config config, Logger logger)
+    {
+        _config = config;
+        _logger = logger;
+        _stabilizeDuration = TimeSpan.FromSeconds(Math.Max(config.StabilizeSeconds, 5));
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _cts.Dispose();
+    }
+
+    public CancellationToken Token => _cts.Token;
+
+    public bool IsAllowedFile(string filePath)
+    {
+        var fileName = Path.GetFileName(filePath);
+        if (string.IsNullOrEmpty(fileName))
+        {
+            return false;
+        }
+
+        if (IsExcluded(fileName))
+        {
+            return false;
+        }
+
+        return AllowedPatterns.Any(pattern => WildcardMatch(pattern, fileName));
+    }
+
+    public bool IsExcluded(string fileName)
+    {
+        foreach (var pattern in _config.ExcludePatterns)
+        {
+            if (WildcardMatch(pattern, fileName))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public async Task<int> ImportTodayAsync(CancellationToken cancellationToken)
+    {
+        var todayStart = DateTime.Today;
+        var processed = 0;
+        if (!Directory.Exists(_config.SourceRoot))
+        {
+            _logger.Warn($"源目录不存在：{_config.SourceRoot}");
+            return 0;
+        }
+
+        var caseDirectories = GetCaseDirectories(_config.SourceRoot);
+        foreach (var caseDir in caseDirectories)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (CaseHasDueFiles(caseDir, todayStart))
+            {
+                await ImportCaseDirectoryAsync(caseDir, cancellationToken).ConfigureAwait(false);
+                processed++;
+            }
+        }
+
+        return processed;
+    }
+
+    public Task ImportCaseFromFileAsync(string filePath, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            return Task.CompletedTask;
+        }
+
+        var caseDirectory = GetCaseDirectoryForFile(filePath);
+        if (caseDirectory == null)
+        {
+            _logger.Warn($"无法确定病例目录：{filePath}");
+            return Task.CompletedTask;
+        }
+
+        return ImportCaseDirectoryAsync(caseDirectory, cancellationToken);
+    }
+
+    public async Task ImportCaseDirectoryAsync(string caseDirectory, CancellationToken cancellationToken)
+    {
+        var fullPath = GetFullPath(caseDirectory);
+        if (string.IsNullOrWhiteSpace(fullPath) || !Directory.Exists(fullPath))
+        {
+            _logger.Warn($"病例目录不存在：{caseDirectory}");
+            return;
+        }
+
+        lock (_caseLock)
+        {
+            if (!_activeCases.Add(fullPath))
+            {
+                return;
+            }
+        }
+
+        try
+        {
+            await Task.Run(() => ImportCaseCore(fullPath, cancellationToken), cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            lock (_caseLock)
+            {
+                _activeCases.Remove(fullPath);
+            }
+        }
+    }
+
+    private void ImportCaseCore(string caseDirectory, CancellationToken cancellationToken)
+    {
+        var todayStart = DateTime.Today;
+        var files = EnumerateAllowedFiles(caseDirectory)
+            .Where(file => ShouldImportFile(file, todayStart));
+
+        foreach (var file in files)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TryCopyFile(file);
+        }
+    }
+
+    private IEnumerable<string> EnumerateAllowedFiles(string root)
+    {
+        if (!Directory.Exists(root))
+        {
+            yield break;
+        }
+
+        IEnumerable<string> files;
+        try
+        {
+            files = Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            _logger.Error(ex, $"枚举文件失败：{root}");
+            yield break;
+        }
+
+        foreach (var file in files)
+        {
+            if (IsAllowedFile(file))
+            {
+                yield return file;
+            }
+        }
+    }
+
+    private bool CaseHasDueFiles(string caseDirectory, DateTime todayStart)
+    {
+        foreach (var file in EnumerateAllowedFiles(caseDirectory))
+        {
+            if (ShouldImportFile(file, todayStart))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool ShouldImportFile(string filePath, DateTime todayStart)
+    {
+        try
+        {
+            var info = new FileInfo(filePath);
+            var lastWrite = info.LastWriteTime;
+            if (lastWrite < todayStart)
+            {
+                return false;
+            }
+
+            var diff = DateTime.Now - lastWrite;
+            return diff >= _stabilizeDuration;
+        }
+        catch (IOException ex)
+        {
+            _logger.Error(ex, $"读取文件时间失败：{filePath}");
+            return false;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            _logger.Error(ex, $"读取文件时间失败：{filePath}");
+            return false;
+        }
+    }
+
+    private void TryCopyFile(string sourcePath)
+    {
+        var relativePath = Path.GetRelativePath(_config.SourceRoot, sourcePath);
+        if (relativePath.StartsWith(".."))
+        {
+            _logger.Warn($"忽略越界文件：{sourcePath}");
+            return;
+        }
+        var today = DateTime.Today;
+        var targetRoot = Path.Combine(_config.ArchiveRoot, today.ToString("yyyy"), today.ToString("yyyy-MM-dd"));
+        var targetPath = Path.Combine(targetRoot, relativePath);
+
+        var sourceInfo = new FileInfo(sourcePath);
+        var targetInfo = new FileInfo(targetPath);
+        if (targetInfo.Exists && targetInfo.LastWriteTime >= sourceInfo.LastWriteTime)
+        {
+            return;
+        }
+
+        var directory = targetInfo.DirectoryName;
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        const int maxAttempts = 3;
+        var attempt = 0;
+        var delay = TimeSpan.FromSeconds(1);
+        while (attempt < maxAttempts)
+        {
+            attempt++;
+            try
+            {
+                using var sourceStream = new FileStream(NormalizeLongPath(sourcePath), FileMode.Open, FileAccess.Read, FileShare.Read);
+                using var targetStream = new FileStream(NormalizeLongPath(targetPath), FileMode.Create, FileAccess.Write, FileShare.None);
+                sourceStream.CopyTo(targetStream);
+                targetStream.Flush(true);
+                File.SetLastWriteTime(targetPath, sourceInfo.LastWriteTime);
+                File.SetCreationTime(targetPath, sourceInfo.CreationTime);
+                _logger.Info($"已复制：{relativePath}");
+                return;
+            }
+            catch (IOException ex)
+            {
+                _logger.Warn($"复制失败（{attempt}/{maxAttempts}）：{relativePath}，原因：{ex.Message}");
+                if (attempt >= maxAttempts)
+                {
+                    _logger.Error(ex, $"复制文件失败：{sourcePath}");
+                    return;
+                }
+
+                Thread.Sleep(delay);
+                delay = TimeSpan.FromSeconds(delay.TotalSeconds * 2);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.Error(ex, $"无权限复制：{sourcePath}");
+                return;
+            }
+        }
+    }
+
+    private static string GetFullPath(string path)
+    {
+        try
+        {
+            return Path.GetFullPath(path);
+        }
+        catch
+        {
+            return path;
+        }
+    }
+
+    private string? GetCaseDirectoryForFile(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(_config.SourceRoot))
+        {
+            return null;
+        }
+
+        try
+        {
+            var fullSourceRoot = Path.GetFullPath(_config.SourceRoot);
+            var fullFile = Path.GetFullPath(filePath);
+            if (!fullFile.StartsWith(fullSourceRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            var relative = Path.GetRelativePath(fullSourceRoot, fullFile);
+            var segments = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            if (segments.Length == 0)
+            {
+                return null;
+            }
+
+            var caseFolder = segments[0];
+            return Path.Combine(fullSourceRoot, caseFolder);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private IEnumerable<string> GetCaseDirectories(string root)
+    {
+        if (!Directory.Exists(root))
+        {
+            yield break;
+        }
+
+        foreach (var directory in Directory.EnumerateDirectories(root))
+        {
+            yield return directory;
+        }
+    }
+
+    private static bool WildcardMatch(string pattern, string input)
+    {
+        if (pattern == null)
+        {
+            return false;
+        }
+
+        var regexPattern = "^" + System.Text.RegularExpressions.Regex.Escape(pattern)
+            .Replace("\\*", ".*")
+            .Replace("\\?", ".") + "$";
+        return System.Text.RegularExpressions.Regex.IsMatch(input, regexPattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+    }
+
+    private static string NormalizeLongPath(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return path;
+        }
+
+        if (path.StartsWith("\\\\?\\"))
+        {
+            return path;
+        }
+
+        if (path.Length >= 260)
+        {
+            if (Path.IsPathRooted(path))
+            {
+                return "\\\\?\\" + path;
+            }
+        }
+
+        return path;
+    }
+}

--- a/ExocadDailyExporter/Services/Logger.cs
+++ b/ExocadDailyExporter/Services/Logger.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace ExocadDailyExporter.Services;
+
+public class Logger
+{
+    private readonly string _logDirectory;
+    private readonly int _keepDays;
+    private readonly object _cleanupLock = new();
+    private readonly ConcurrentQueue<string> _recentMessages = new();
+
+    public event EventHandler<string>? MessageLogged;
+
+    public Logger(int keepDays)
+    {
+        _keepDays = keepDays;
+        _logDirectory = Path.Combine(AppContext.BaseDirectory, "logs");
+    }
+
+    public string LogDirectory => _logDirectory;
+
+    public string CurrentLogPath => Path.Combine(_logDirectory, $"archive-{DateTime.Now:yyyyMMdd}.log");
+
+    public void Info(string message) => Write("INFO", message);
+
+    public void Warn(string message) => Write("WARN", message);
+
+    public void Error(string message) => Write("ERROR", message);
+
+    public void Error(Exception ex, string message)
+    {
+        var text = new StringBuilder();
+        text.AppendLine(message);
+        text.AppendLine(ex.ToString());
+        Write("ERROR", text.ToString().TrimEnd());
+    }
+
+    private void Write(string level, string message)
+    {
+        var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+        var line = $"[{timestamp}] [{level}] {message}";
+
+        Directory.CreateDirectory(_logDirectory);
+        File.AppendAllText(CurrentLogPath, line + Environment.NewLine, Encoding.UTF8);
+        _recentMessages.Enqueue(line);
+        while (_recentMessages.Count > 200 && _recentMessages.TryDequeue(out _))
+        {
+        }
+
+        MessageLogged?.Invoke(this, line);
+        TryCleanup();
+    }
+
+    private void TryCleanup()
+    {
+        lock (_cleanupLock)
+        {
+            if (!Directory.Exists(_logDirectory))
+            {
+                return;
+            }
+
+            var threshold = DateTime.Now.Date.AddDays(-_keepDays);
+            foreach (var file in Directory.EnumerateFiles(_logDirectory, "archive-*.log"))
+            {
+                try
+                {
+                    var name = Path.GetFileNameWithoutExtension(file);
+                    if (name?.Length >= 15)
+                    {
+                        var datePart = name.Substring("archive-".Length);
+                        if (DateTime.TryParseExact(datePart, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date)
+                            && date < threshold)
+                        {
+                            File.Delete(file);
+                        }
+                    }
+                }
+                catch
+                {
+                    // ignore cleanup errors
+                }
+            }
+        }
+    }
+
+    public string[] GetRecentMessages()
+    {
+        return _recentMessages.ToArray();
+    }
+}

--- a/ExocadDailyExporter/Services/SchedulerService.cs
+++ b/ExocadDailyExporter/Services/SchedulerService.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using ExocadDailyExporter.Models;
+
+namespace ExocadDailyExporter.Services;
+
+public class SchedulerService
+{
+    private readonly Config _config;
+    private readonly Logger _logger;
+    private readonly string _dailyTaskName = "ExocadDailyExporter-Daily";
+    private readonly string _startupTaskName = "ExocadDailyExporter-Startup";
+
+    public SchedulerService(Config config, Logger logger)
+    {
+        _config = config;
+        _logger = logger;
+    }
+
+    public string? LastError { get; private set; }
+
+    public bool EnsureDailyTask()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            LastError = "仅支持在 Windows 上创建计划任务";
+            return false;
+        }
+
+        try
+        {
+            var exePath = Path.Combine(AppContext.BaseDirectory, AppDomain.CurrentDomain.FriendlyName + ".exe");
+            if (!File.Exists(exePath) && Environment.ProcessPath is { } current)
+            {
+                exePath = current;
+            }
+
+            var dailyTime = _config.GetDailyTimeOfDay();
+            var startTime = new DateTime(1, 1, 1, dailyTime.Hours, dailyTime.Minutes, 0).ToString("HH:mm");
+            var command = $"{Quote(exePath)} --daily-run";
+            var args = $"/Create /F /SC DAILY /TN {_dailyTaskName} /ST {startTime} /RL LIMITED /TR {Quote(command)}";
+            return RunSchTasks(args);
+        }
+        catch (Exception ex)
+        {
+            LastError = ex.Message;
+            _logger.Error(ex, "创建每日计划任务失败");
+            return false;
+        }
+    }
+
+    public bool RemoveDailyTask()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return true;
+        }
+
+        return RunSchTasks($"/Delete /TN {_dailyTaskName} /F", suppressError: true);
+    }
+
+    public bool ConfigureStartupTask(bool enable)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            LastError = "仅支持在 Windows 上配置自启";
+            return false;
+        }
+
+        try
+        {
+            if (enable)
+            {
+                var exePath = Environment.ProcessPath ?? Path.Combine(AppContext.BaseDirectory, AppDomain.CurrentDomain.FriendlyName + ".exe");
+                var args = $"/Create /F /SC ONLOGON /TN {_startupTaskName} /RL LIMITED /TR {Quote(exePath)}";
+                return RunSchTasks(args);
+            }
+            else
+            {
+                return RunSchTasks($"/Delete /TN {_startupTaskName} /F", suppressError: true);
+            }
+        }
+        catch (Exception ex)
+        {
+            LastError = ex.Message;
+            _logger.Error(ex, "配置自启任务失败");
+            return false;
+        }
+    }
+
+    private bool RunSchTasks(string arguments, bool suppressError = false)
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "schtasks",
+                    Arguments = arguments,
+                    CreateNoWindow = true,
+                    UseShellExecute = false,
+                    RedirectStandardError = true,
+                    RedirectStandardOutput = true,
+                    StandardErrorEncoding = Encoding.UTF8,
+                    StandardOutputEncoding = Encoding.UTF8
+                }
+            };
+
+            process.Start();
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+            {
+                if (suppressError)
+                {
+                    return true;
+                }
+
+                LastError = string.IsNullOrWhiteSpace(error) ? output : error;
+                _logger.Warn($"schtasks 返回码 {process.ExitCode}：{LastError}");
+                return false;
+            }
+
+            _logger.Info($"schtasks 执行成功：{arguments}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            if (!suppressError)
+            {
+                LastError = ex.Message;
+                _logger.Error(ex, "运行 schtasks 失败");
+            }
+
+            return false;
+        }
+    }
+
+    private static string Quote(string value) => $"\"{value}\"";
+}

--- a/ExocadDailyExporter/Services/StartupService.cs
+++ b/ExocadDailyExporter/Services/StartupService.cs
@@ -1,0 +1,130 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using ExocadDailyExporter.Models;
+
+namespace ExocadDailyExporter.Services;
+
+public class StartupService
+{
+    private readonly SchedulerService _schedulerService;
+    private readonly Config _config;
+    private readonly Logger _logger;
+    private readonly string _shortcutName = "ExocadDailyExporter.lnk";
+
+    public StartupService(Config config, SchedulerService schedulerService, Logger logger)
+    {
+        _config = config;
+        _schedulerService = schedulerService;
+        _logger = logger;
+    }
+
+    public string? LastError { get; private set; }
+
+    public string? FallbackMessage { get; private set; }
+
+    public bool ApplyStartupSetting()
+    {
+        FallbackMessage = null;
+        LastError = null;
+
+        var enable = _config.RunAtStartup;
+        if (!OperatingSystem.IsWindows())
+        {
+            LastError = "当前系统不支持开机自启配置";
+            return false;
+        }
+
+        if (_schedulerService.ConfigureStartupTask(enable))
+        {
+            RemoveStartupFolderShortcut();
+            return true;
+        }
+
+        LastError = _schedulerService.LastError;
+        if (enable)
+        {
+            if (TryConfigureStartupFolder())
+            {
+                FallbackMessage = "计划任务创建失败，已改用启动文件夹自启。";
+                return true;
+            }
+        }
+        else
+        {
+            RemoveStartupFolderShortcut();
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryConfigureStartupFolder()
+    {
+        try
+        {
+            var startupPath = Environment.GetFolderPath(Environment.SpecialFolder.Startup);
+            if (string.IsNullOrWhiteSpace(startupPath))
+            {
+                return false;
+            }
+
+            Directory.CreateDirectory(startupPath);
+            var shortcutPath = Path.Combine(startupPath, _shortcutName);
+            CreateShortcut(shortcutPath);
+            _logger.Info($"已创建启动文件夹快捷方式：{shortcutPath}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            LastError = ex.Message;
+            _logger.Error(ex, "创建启动文件夹快捷方式失败");
+            return false;
+        }
+    }
+
+    private void RemoveStartupFolderShortcut()
+    {
+        try
+        {
+            var startupPath = Environment.GetFolderPath(Environment.SpecialFolder.Startup);
+            var shortcutPath = Path.Combine(startupPath, _shortcutName);
+            if (File.Exists(shortcutPath))
+            {
+                File.Delete(shortcutPath);
+                _logger.Info("已移除启动文件夹快捷方式");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "删除启动文件夹快捷方式失败");
+        }
+    }
+
+    private void CreateShortcut(string shortcutPath)
+    {
+        var target = Environment.ProcessPath ?? Path.Combine(AppContext.BaseDirectory, AppDomain.CurrentDomain.FriendlyName + ".exe");
+        var shellType = Type.GetTypeFromProgID("WScript.Shell");
+        if (shellType == null)
+        {
+            throw new InvalidOperationException("无法访问 WScript.Shell");
+        }
+
+        dynamic shell = Activator.CreateInstance(shellType) ?? throw new InvalidOperationException("创建 WScript.Shell 实例失败");
+        try
+        {
+            dynamic shortcut = shell.CreateShortcut(shortcutPath);
+            shortcut.TargetPath = target;
+            shortcut.WorkingDirectory = Path.GetDirectoryName(target);
+            shortcut.IconLocation = target;
+            shortcut.Save();
+        }
+        finally
+        {
+            if (shell is not null && Marshal.IsComObject(shell))
+            {
+                Marshal.FinalReleaseComObject(shell);
+            }
+        }
+    }
+}

--- a/ExocadDailyExporter/Services/WatcherService.cs
+++ b/ExocadDailyExporter/Services/WatcherService.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Threading;
+using ExocadDailyExporter.Models;
+
+namespace ExocadDailyExporter.Services;
+
+public class WatcherService : IDisposable
+{
+    private readonly Config _config;
+    private readonly ImportService _importService;
+    private readonly Logger _logger;
+    private readonly ConcurrentDictionary<string, DateTime> _pending = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Timer _timer;
+    private FileSystemWatcher? _watcher;
+    private bool _disposed;
+
+    public WatcherService(Config config, ImportService importService, Logger logger)
+    {
+        _config = config;
+        _importService = importService;
+        _logger = logger;
+        _timer = new Timer(ProcessQueue, null, Timeout.Infinite, Timeout.Infinite);
+    }
+
+    public void Start()
+    {
+        Stop();
+
+        if (string.IsNullOrWhiteSpace(_config.SourceRoot) || !Directory.Exists(_config.SourceRoot))
+        {
+            _logger.Warn($"未找到源目录：{_config.SourceRoot}");
+            return;
+        }
+
+        _watcher = new FileSystemWatcher(_config.SourceRoot)
+        {
+            IncludeSubdirectories = true,
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName,
+            Filter = "*"
+        };
+
+        _watcher.Created += OnChanged;
+        _watcher.Changed += OnChanged;
+        _watcher.Renamed += OnRenamed;
+        _watcher.EnableRaisingEvents = true;
+
+        var interval = Math.Max(5, _config.StabilizeSeconds / 2);
+        _timer.Change(TimeSpan.FromSeconds(interval), TimeSpan.FromSeconds(interval));
+        _logger.Info("文件监视服务已启动");
+    }
+
+    public void Stop()
+    {
+        if (_watcher != null)
+        {
+            _watcher.EnableRaisingEvents = false;
+            _watcher.Created -= OnChanged;
+            _watcher.Changed -= OnChanged;
+            _watcher.Renamed -= OnRenamed;
+            _watcher.Dispose();
+            _watcher = null;
+        }
+
+        _pending.Clear();
+        _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+    }
+
+    private void OnChanged(object sender, FileSystemEventArgs e)
+    {
+        if (_importService.IsAllowedFile(e.FullPath))
+        {
+            _pending[e.FullPath] = DateTime.Now.AddSeconds(_config.StabilizeSeconds);
+        }
+    }
+
+    private void OnRenamed(object sender, RenamedEventArgs e)
+    {
+        if (!string.IsNullOrEmpty(e.OldFullPath))
+        {
+            _pending.TryRemove(e.OldFullPath, out _);
+        }
+
+        if (_importService.IsAllowedFile(e.FullPath))
+        {
+            _pending[e.FullPath] = DateTime.Now.AddSeconds(_config.StabilizeSeconds);
+        }
+    }
+
+    private void ProcessQueue(object? state)
+    {
+        if (_pending.IsEmpty)
+        {
+            return;
+        }
+
+        var now = DateTime.Now;
+        foreach (var kvp in _pending.ToArray())
+        {
+            if (kvp.Value <= now && _pending.TryRemove(kvp.Key, out _))
+            {
+                _ = _importService.ImportCaseFromFileAsync(kvp.Key, _importService.Token);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        Stop();
+        _timer.Dispose();
+    }
+}

--- a/ExocadDailyExporter/TrayAppContext.cs
+++ b/ExocadDailyExporter/TrayAppContext.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using ExocadDailyExporter.Models;
+using ExocadDailyExporter.Services;
+
+namespace ExocadDailyExporter;
+
+public class TrayAppContext : ApplicationContext
+{
+    private readonly NotifyIcon _notifyIcon;
+    private Config _config;
+    private Logger _logger;
+    private ImportService _importService;
+    private WatcherService _watcherService;
+    private SchedulerService _schedulerService;
+    private StartupService _startupService;
+    private MainForm? _mainForm;
+    private string? _statusMessage;
+    private bool _isExiting;
+
+    public TrayAppContext()
+    {
+        _config = Config.Load();
+        InitializeServices();
+
+        _notifyIcon = new NotifyIcon
+        {
+            Icon = LoadIcon(),
+            Text = "ExocadDailyExporter",
+            Visible = true,
+            ContextMenuStrip = BuildMenu()
+        };
+        _notifyIcon.DoubleClick += (_, _) => ShowMainForm();
+
+        _logger.Info("程序已启动");
+
+        if (string.IsNullOrWhiteSpace(_config.ArchiveRoot))
+        {
+            ShowFirstRunDialog();
+        }
+        else
+        {
+            StartBackgroundServices();
+        }
+    }
+
+    private void InitializeServices()
+    {
+        _watcherService?.Dispose();
+        _importService?.Dispose();
+        if (_logger != null)
+        {
+            _logger.MessageLogged -= OnLogMessage;
+        }
+
+        _logger = new Logger(_config.KeepLogDays);
+        _logger.MessageLogged += OnLogMessage;
+        _importService = new ImportService(_config, _logger);
+        _watcherService = new WatcherService(_config, _importService, _logger);
+        _schedulerService = new SchedulerService(_config, _logger);
+        _startupService = new StartupService(_config, _schedulerService, _logger);
+    }
+
+    private ContextMenuStrip BuildMenu()
+    {
+        var menu = new ContextMenuStrip();
+        menu.Items.Add("设置...", null, (_, _) => ShowMainForm());
+        menu.Items.Add("立刻导入今天", null, async (_, _) => await RunFullImportAsync());
+        menu.Items.Add("打开归档文件夹", null, (_, _) => OpenDirectory(_config.ArchiveRoot));
+        menu.Items.Add("打开日志文件夹", null, (_, _) => OpenDirectory(_logger.LogDirectory));
+        menu.Items.Add("退出", null, (_, _) => ExitApplication());
+        return menu;
+    }
+
+    private void ShowFirstRunDialog()
+    {
+        using var form = new FirstRunForm(_config.ArchiveRoot);
+        if (form.ShowDialog() == DialogResult.OK)
+        {
+            if (string.IsNullOrWhiteSpace(form.ArchiveRoot))
+            {
+                ExitApplication();
+                return;
+            }
+
+            _config.ArchiveRoot = form.ArchiveRoot;
+            _config.Save();
+            InitializeServices();
+            StartBackgroundServices();
+
+            if (form.Result == FirstRunResult.StartNow)
+            {
+                _ = RunFullImportAsync();
+            }
+        }
+        else
+        {
+            ExitApplication();
+        }
+    }
+
+    private void StartBackgroundServices()
+    {
+        if (string.IsNullOrWhiteSpace(_config.ArchiveRoot))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(_config.ArchiveRoot);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "创建归档目录失败");
+        }
+
+        _watcherService.Start();
+
+        var schedulerOk = _schedulerService.EnsureDailyTask();
+        if (!schedulerOk && !string.IsNullOrWhiteSpace(_schedulerService.LastError))
+        {
+            _logger.Warn($"计划任务配置失败：{_schedulerService.LastError}");
+            _statusMessage = $"计划任务失败：{_schedulerService.LastError}";
+        }
+        else
+        {
+            _statusMessage = null;
+        }
+
+        if (!_startupService.ApplyStartupSetting() && !string.IsNullOrWhiteSpace(_startupService.LastError))
+        {
+            _logger.Warn($"自启配置失败：{_startupService.LastError}");
+            _statusMessage = string.IsNullOrEmpty(_statusMessage)
+                ? $"自启配置失败：{_startupService.LastError}"
+                : _statusMessage + Environment.NewLine + $"自启配置失败：{_startupService.LastError}";
+        }
+        else if (!string.IsNullOrWhiteSpace(_startupService.FallbackMessage))
+        {
+            _logger.Warn(_startupService.FallbackMessage);
+            _statusMessage = string.IsNullOrEmpty(_statusMessage)
+                ? _startupService.FallbackMessage
+                : _statusMessage + Environment.NewLine + _startupService.FallbackMessage;
+        }
+
+        UpdateMainFormConfig();
+        UpdateMainFormStatus();
+        ShowBalloon("ExocadDailyExporter 已在后台运行。", ToolTipIcon.Info);
+    }
+
+    private Icon LoadIcon()
+    {
+        var iconPath = Path.Combine(AppContext.BaseDirectory, "app.ico");
+        if (File.Exists(iconPath))
+        {
+            try
+            {
+                return new Icon(iconPath);
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+
+        return SystemIcons.Application;
+    }
+
+    private void ShowMainForm()
+    {
+        if (_mainForm == null || _mainForm.IsDisposed)
+        {
+            _mainForm = new MainForm(_config);
+            _mainForm.SaveRequested += OnSaveRequested;
+            _mainForm.ImportTodayRequested += async (_, _) => await RunFullImportAsync();
+            _mainForm.OpenArchiveRequested += (_, _) => OpenDirectory(_config.ArchiveRoot);
+            _mainForm.OpenLogsRequested += (_, _) => OpenDirectory(_logger.LogDirectory);
+            _mainForm.FormClosing += OnMainFormClosing;
+            foreach (var message in _logger.GetRecentMessages())
+            {
+                _mainForm.AppendLog(message);
+            }
+            UpdateMainFormStatus();
+        }
+
+        _mainForm.Show();
+        _mainForm.WindowState = FormWindowState.Normal;
+        _mainForm.Activate();
+    }
+
+    private void OnMainFormClosing(object? sender, FormClosingEventArgs e)
+    {
+        if (e.CloseReason == CloseReason.UserClosing)
+        {
+            e.Cancel = true;
+            _mainForm?.Hide();
+        }
+    }
+
+    private async Task RunFullImportAsync()
+    {
+        if (_importService == null)
+        {
+            return;
+        }
+
+        try
+        {
+            _logger.Info("开始执行今日全量扫描...");
+            var count = await _importService.ImportTodayAsync(CancellationToken.None).ConfigureAwait(false);
+            _logger.Info($"今日全量扫描完成，共处理 {count} 个病例。");
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "今日全量扫描失败");
+        }
+    }
+
+    private void OnSaveRequested(object? sender, Config newConfig)
+    {
+        if (string.IsNullOrWhiteSpace(newConfig.ArchiveRoot))
+        {
+            MessageBox.Show(_mainForm, "归档路径不能为空。", "设置", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            return;
+        }
+
+        _config = newConfig;
+        _config.Save();
+        InitializeServices();
+        StartBackgroundServices();
+        _logger.Info("配置已保存并应用");
+        ShowBalloon("配置已保存并应用。", ToolTipIcon.Info);
+    }
+
+    private void UpdateMainFormConfig()
+    {
+        if (_mainForm != null && !_mainForm.IsDisposed)
+        {
+            _mainForm.LoadConfig(_config);
+        }
+    }
+
+    private void UpdateMainFormStatus()
+    {
+        if (_mainForm != null && !_mainForm.IsDisposed)
+        {
+            _mainForm.SetStatusMessage(_statusMessage);
+        }
+    }
+
+    private void OnLogMessage(object? sender, string message)
+    {
+        _mainForm?.AppendLog(message);
+    }
+
+    private void OpenDirectory(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            MessageBox.Show("尚未设置路径。", "提示", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        try
+        {
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
+
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = path,
+                UseShellExecute = true
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, $"打开目录失败：{path}");
+            MessageBox.Show($"无法打开目录：{ex.Message}", "错误", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private void ShowBalloon(string text, ToolTipIcon icon)
+    {
+        _notifyIcon.BalloonTipText = text;
+        _notifyIcon.BalloonTipIcon = icon;
+        _notifyIcon.BalloonTipTitle = "ExocadDailyExporter";
+        _notifyIcon.ShowBalloonTip(3000);
+    }
+
+    private void ExitApplication()
+    {
+        if (_isExiting)
+        {
+            return;
+        }
+
+        _isExiting = true;
+        ExitThread();
+    }
+
+    protected override void ExitThreadCore()
+    {
+        _notifyIcon.Visible = false;
+        _notifyIcon.Dispose();
+        _watcherService?.Dispose();
+        _importService?.Dispose();
+        if (_logger != null)
+        {
+            _logger.MessageLogged -= OnLogMessage;
+        }
+        base.ExitThreadCore();
+    }
+}

--- a/ExocadDailyExporter/appsettings.json
+++ b/ExocadDailyExporter/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "SourceRoot": "D:\\Exocad-Allinone-3.0\\CAD\\exocad-DentalCAD3.0-2021-03-25\\CAD-Data",
+  "ArchiveRoot": "",
+  "StabilizeSeconds": 30,
+  "DailyTime": "19:00",
+  "RunAtStartup": true,
+  "KeepLogDays": 30,
+  "ExcludePatterns": [
+    "crashreport*",
+    "*preview*.stl",
+    "*screenshot*.png"
+  ]
+}

--- a/ExocadDailyExporter/build.ps1
+++ b/ExocadDailyExporter/build.ps1
@@ -1,0 +1,39 @@
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$root = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $root
+
+$dist = Join-Path $root 'dist'
+$publishDir = Join-Path $dist 'win-x64'
+$zipPath = Join-Path $dist 'ExocadDailyExporter-win-x64.zip'
+
+if (Test-Path $dist) {
+    Remove-Item $dist -Recurse -Force
+}
+
+New-Item -ItemType Directory -Path $publishDir | Out-Null
+
+Write-Host 'Restore packages...'
+dotnet restore ..\ExocadDailyExporter.sln
+
+Write-Host 'Publish self-contained package...'
+dotnet publish ..\ExocadDailyExporter.sln -c Release -r win-x64 -p:PublishSingleFile=true -p:SelfContained=true -p:IncludeNativeLibrariesForSelfExtract=true -p:EnableCompressionInSingleFile=true -o $publishDir
+
+Write-Host 'Copy configuration and README...'
+Copy-Item (Join-Path $root 'appsettings.json') $publishDir -Force
+Copy-Item (Join-Path $root 'README.md') $publishDir -Force
+
+if (Test-Path $zipPath) {
+    Remove-Item $zipPath -Force
+}
+
+Write-Host 'Create zip package...'
+Compress-Archive -Path (Join-Path $publishDir '*') -DestinationPath $zipPath
+
+$downloadLink = "file:///$($zipPath.Replace('\', '/'))"
+Set-Content -Path (Join-Path $dist 'download-link.txt') -Value $downloadLink -Encoding UTF8
+
+Write-Host "打包完成: $zipPath"
+Write-Host "下载链接: $downloadLink"


### PR DESCRIPTION
## Summary
- create the ExocadDailyExporter WinForms tray application with first-run wizard, configuration UI, logging, and background services
- implement import, watcher, scheduler, and startup helpers to process exocad manufacturing files into the daily archive structure
- add build script, GitHub Actions release workflow, documentation, and unit tests for file selection and copy logic

## Testing
- not run (dotnet CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e7373b36048331865a7cfb406060ca